### PR TITLE
Add gem Git source to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Ruby library for parsing the unified diff format generated with `git diff`
 
 Add this line to your application's Gemfile:
 
-    gem 'git_diff'
+    gem 'git_diff', git: 'https://github.com/anolson/git_diff.git'
 
 And then execute:
 


### PR DESCRIPTION
Hi!

Installing the gem from Rubygems source didn't work for me, presumably one needs to be installed from GitHub. Added to `README.md`.

Thanks,
Alex