### PR TITLE
Fix default value for count in line range

### DIFF
--- a/lib/git_diff/line_number_range.rb
+++ b/lib/git_diff/line_number_range.rb
@@ -6,7 +6,7 @@ module GitDiff
       new(*string.split(","))
     end
 
-    def initialize(start = 0, number_of_lines = 0)
+    def initialize(start = 0, number_of_lines = 1)
       @start = start.to_i
       @number_of_lines = number_of_lines.to_i
     end

--- a/test/line_number_range_test.rb
+++ b/test/line_number_range_test.rb
@@ -6,7 +6,7 @@ class LineNumberRangeTest < Minitest::Test
     range = GitDiff::LineNumberRange.from_string("")
 
     assert_equal 0, range.start
-    assert_equal 0, range.number_of_lines
+    assert_equal 1, range.number_of_lines
   end
 
   def test_from_string_with_not_empty_string
@@ -14,6 +14,13 @@ class LineNumberRangeTest < Minitest::Test
 
     assert_equal 180, range.start
     assert_equal 7, range.number_of_lines
+  end
+
+  def test_from_string_with_start_no_count
+    range = GitDiff::LineNumberRange.from_string("180")
+
+    assert_equal 180, range.start
+    assert_equal 1, range.number_of_lines
   end
 
   def test_to_s


### PR DESCRIPTION
In unified diff line number range has following format `start,count`, e.g. `4,2`.
It is allowed to omit count if the count equals 1, i.e. `4` is same as `4,1`.

> If a hunk contains just one line, only its start line number appears. Otherwise its line numbers look like ‘start,count’.
http://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html#Detailed-Unified