### PR TITLE
Allow quotations around filenames

### DIFF
--- a/lib/git_diff/file.rb
+++ b/lib/git_diff/file.rb
@@ -54,11 +54,11 @@ module GitDiff
     def extract_diff_meta_data(string)
       if a_path_info = %r{^[-]{3} /dev/null(.*)$}.match(string)
         @a_path = "/dev/null"
-      elsif a_path_info = %r{^[-]{3} a/(.*)$}.match(string)
+      elsif a_path_info = %r{^[-]{3} "?a/(.*)$}.match(string)
         @a_path = a_path_info[1]
       elsif b_path_info = %r{^[+]{3} /dev/null(.*)$}.match(string)
         @b_path = "/dev/null"
-      elsif b_path_info = %r{^[+]{3} b/(.*)$}.match(string)
+      elsif b_path_info = %r{^[+]{3} "?b/(.*)$}.match(string)
         @b_path = b_path_info[1]
       elsif blob_info = /^index ([0-9A-Fa-f]+)\.\.([0-9A-Fa-f]+) ?(.+)?$/.match(string)
         @a_blob, @b_blob, @b_mode = *blob_info.captures
@@ -78,7 +78,7 @@ module GitDiff
         else
           @b_path = copy_rename_info.captures[2]
         end
-      elsif binary_info = %r{^Binary files (?:/dev/null|a/(.*)) and (?:/dev/null|b/(.*)) differ$}.match(string)
+      elsif binary_info = %r{^Binary files (?:/dev/null|"?a/(.*)) and (?:/dev/null|"?b/(.*)) differ$}.match(string)
         @binary = true
         @a_path ||= binary_info[1] || "/dev/null"
         @b_path ||= binary_info[2] || "/dev/null"


### PR DESCRIPTION
Recently, I ran into a bug in which a line containing an unusual character was not parsed correctly by this gem. By inspecting the diff, I discovered that it was because `git` adds quotations around pathnames containing unusual characters (see https://git-scm.com/docs/git-config#git-config-corequotePath).

The problematic section of the diff looked something like the following:
```diff
--- "a/app/foo/bar/FOO\357\234\202"
+++ b/app/foo/bar/FOO
```

This pull request changes the diff metadata regular expressions to allow for such quoted strings.