### PR TITLE
Change Line classes inheritance tree structure

### DIFF
--- a/lib/git_diff/line.rb
+++ b/lib/git_diff/line.rb
@@ -1,3 +1,4 @@
+require "git_diff/line/base"
 require "git_diff/line/context"
 require "git_diff/line/addition"
 require "git_diff/line/deletion"

--- a/lib/git_diff/line/addition.rb
+++ b/lib/git_diff/line/addition.rb
@@ -1,6 +1,6 @@
 module GitDiff
   module Line
-    class Addition < Context
+    class Addition < Base
       def line_number=(line_number)
         @line_number = LineNumber.for_addition(line_number)
       end

--- a/lib/git_diff/line/base.rb
+++ b/lib/git_diff/line/base.rb
@@ -1,0 +1,28 @@
+module GitDiff
+  module Line
+    class Base
+      attr_reader :content, :line_number
+
+      def initialize(content, line_number=nil)
+        @content = content
+        @line_number = line_number
+      end
+
+      def context?
+        false
+      end
+
+      def deletion?
+        false
+      end
+
+      def addition?
+        false
+      end
+
+      def to_s
+        content
+      end
+    end
+  end
+end

--- a/lib/git_diff/line/context.rb
+++ b/lib/git_diff/line/context.rb
@@ -1,27 +1,12 @@
 module GitDiff
   module Line
-    class Context
-      attr_reader :content, :line_number
-
-      def initialize(content, line_number=nil)
-        @content = content
-        @line_number = line_number
-      end
-
+    class Context < Base
       def line_number=(line_number)
         @line_number = LineNumber.for_context(line_number)
       end
 
-      def deletion?
-        false
-      end
-
-      def addition?
-        false
-      end
-
-      def to_s
-        content
+      def context?
+        true
       end
     end
   end

--- a/lib/git_diff/line/deletion.rb
+++ b/lib/git_diff/line/deletion.rb
@@ -1,6 +1,6 @@
 module GitDiff
   module Line
-    class Deletion < Context
+    class Deletion < Base
       def line_number=(line_number)
         @line_number = LineNumber.for_deletion(line_number)
       end

--- a/test/line/addition_test.rb
+++ b/test/line/addition_test.rb
@@ -9,6 +9,10 @@ class AdditionTest < Minitest::Test
     assert @addition.addition?
   end
 
+  def test_context_is_false
+    refute @addition.context?
+  end
+
   def test_deletion_is_false
     refute @addition.deletion?
   end

--- a/test/line/context_test.rb
+++ b/test/line/context_test.rb
@@ -11,6 +11,10 @@ class ContextTest < Minitest::Test
     refute @context.addition?
   end
 
+  def test_context_is_true
+    assert @context.context?
+  end
+
   def test_deletion_is_false
     refute @context.deletion?
   end

--- a/test/line/deletion_test.rb
+++ b/test/line/deletion_test.rb
@@ -9,6 +9,10 @@ class DeletionTest < Minitest::Test
     refute @deletion.addition?
   end
 
+  def test_context_is_false
+    refute @deletion.context?
+  end
+
   def test_deletion_is_true
     assert @deletion.deletion?
   end


### PR DESCRIPTION
## About

so that an Addition (or a Deletion) is not a kind of Context.

Before:

```
GitDiff::Line::Context
|- GitDiff::Line::Addition
`- GitDiff::Line::Deletion
```

After:

```
GitDiff::Line::Base
|- GitDiff::Line::Addition
|- GitDiff::Line::Context
`- GitDiff::Line::Deletion
```

## Background

The reason why I added this change is to check if a line is a context line or not in an easy way.

I recently used git_diff at https://github.com/r7kamura/danger-suggester/blob/db7379f885e7b1cff060a662aabe0b219ae190dc/lib/danger/suggester/hunk.rb#L19-L27.

In this lines, I wrote the following code:

```rb
@hunk.lines.chunk_while do |a, b|
  a.instance_of?(::GitDiff::Line::Context) && b.instance_of?(::GitDiff::Line::Context) ||
    a.instance_of?(::GitDiff::Line::Deletion) && b.instance_of?(::GitDiff::Line::Deletion) ||
    a.instance_of?(::GitDiff::Line::Deletion) && b.instance_of?(::GitDiff::Line::Addition) ||
    a.instance_of?(::GitDiff::Line::Addition) && b.instance_of?(::GitDiff::Line::Addition)
end
```

but the truth is that I wanted to write my code like this (without taking care of the difference between `#instance_of?` and `#is_a?`):

```rb
@hunk.lines.chunk_while do |a, b|
  a.is_a?(::GitDiff::Line::Context) && b.is_a?(::GitDiff::Line::Context) ||
    a.is_a?(::GitDiff::Line::Deletion) && b.is_a?(::GitDiff::Line::Deletion) ||
    a.is_a?(::GitDiff::Line::Deletion) && b.is_a?(::GitDiff::Line::Addition) ||
    a.is_a?(::GitDiff::Line::Addition) && b.is_a?(::GitDiff::Line::Addition)
end
```

or even like this:

```rb
@hunk.lines.chunk_while do |a, b|
  a.context? && b.context? ||
    a.deletion? && b.deletion? ||
    a.deletion? && b.addition? ||
    a.addition? && b.addition?
end
```